### PR TITLE
Trim left on the class string created by tailwind method

### DIFF
--- a/src/Tailwind.elm
+++ b/src/Tailwind.elm
@@ -36,7 +36,7 @@ tailwind cs =
         folder (TailwindClass c) memo =
             memo ++ " " ++ c
     in
-    Html.Attributes.class <| List.foldl folder "" cs
+    Html.Attributes.class <| String.trimLeft <| List.foldl folder "" cs
 
 
 {-| A convenience function for adding non-tailwind classes to an element alongside other tailwind classes.


### PR DESCRIPTION
This is to fix: https://github.com/afidegnum/elm-tailwind/issues/2#issue-410941769

Its not a big deal but having a leading space on the class string created for tailwind is annoying.  ;).